### PR TITLE
Add shebang for portability to check.sh

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 echo ""
 echo "Running Diff"
 echo "--------"


### PR DESCRIPTION
I don't use bash by default, so this script won't run for me without this line. See [this Stack Overflow answer](https://stackoverflow.com/a/10383546/1979008).